### PR TITLE
Fixed ~rule34

### DIFF
--- a/NadekoBot/Modules/NSFW/NSFWModule.cs
+++ b/NadekoBot/Modules/NSFW/NSFWModule.cs
@@ -73,7 +73,10 @@ namespace NadekoBot.Modules.NSFW
                         if (string.IsNullOrWhiteSpace(link))
                             await e.Channel.SendMessage("Search yielded no results ;(");
                         else
-                            await e.Channel.SendMessage(link).ConfigureAwait(false);
+                            if (link.Contains(".webm"))
+                                await e.Channel.SendMessage("Search yielded Video :sob:");
+                            else
+                                await e.Channel.SendMessage(":heart: " + link).ConfigureAwait(false);
                     });
                 cgb.CreateCommand(Prefix + "e621")
                     .Description("Shows a random hentai image from e621.net with a given tag. Tag is optional but preffered. Use spaces for multiple tags.\n**Usage**: ~e621 yuri kissing")


### PR DESCRIPTION
Fixed the issue with ~rule34 displaying .webm files. Bot is now displaying a message if it gets a .webm.
I did not add an automatic new search, because it will result in a permanent search and probably crash while used with tags that are only including .webm files.