### PR TITLE
Basic audio cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,15 @@
 *.userosscache
 *.sln.docstates
 *.pfx
+*.tmp
+*.TMP
+
 obj/
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 **/Bin/Release/
 **/Bin/PRIVATE/
+**/Bin/Debug/cache/
 !**/Bin/Debug/opus.dll
 !**/Bin/Debug/libsodium.dll
 !**/Bin/Debug/Nito.AsyncEx.Enlightenment.dll

--- a/NadekoBot/Classes/Helper.cs
+++ b/NadekoBot/Classes/Helper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NadekoBot.Classes
+{
+    class Helper
+    {
+        public static String BytesSizeToHumanReadable(long byteCount)
+        {
+             string[] suf = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
+            if (byteCount == 0)
+                return "0" + suf[0];
+            long bytes = Math.Abs(byteCount);
+            int place = Convert.ToInt32(Math.Floor(Math.Log(bytes, 1024)));
+            double num = Math.Round(bytes / Math.Pow(1024, place), 1);
+            return (Math.Sign(byteCount) * num).ToString() + suf[place];
+        }
+
+        public static long DirSize(DirectoryInfo d)
+        {
+            long size = 0;
+            // Add file sizes.
+            FileInfo[] fis = d.GetFiles();
+            foreach (FileInfo fi in fis)
+            {
+                size += fi.Length;
+            }
+            // Add subdirectory sizes.
+            DirectoryInfo[] dis = d.GetDirectories();
+            foreach (DirectoryInfo di in dis)
+            {
+                size += DirSize(di);
+            }
+            return size;
+        }
+    }
+}

--- a/NadekoBot/Modules/Administration/AdministrationModule.cs
+++ b/NadekoBot/Modules/Administration/AdministrationModule.cs
@@ -5,10 +5,12 @@ using NadekoBot.Classes;
 using NadekoBot.DataModels;
 using NadekoBot.Extensions;
 using NadekoBot.Modules.Administration.Commands;
+using NadekoBot.Modules.Music.Classes;
 using NadekoBot.Modules.Permissions.Classes;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -893,6 +895,37 @@ namespace NadekoBot.Modules.Administration
                             cnt -= 100;
                         }
                         await e.User.SendFile($"Chatlog-{e.Server.Name}/#{e.Channel.Name}-{DateTime.Now}.txt", JsonConvert.SerializeObject(new { Messages = msgs.Select(s => s.ToString()) }, Formatting.Indented).ToStream()).ConfigureAwait(false);
+                    });
+
+                cgb.CreateCommand(Prefix + "clearcache")
+                    .Description("Clear the audio cache")
+                    .AddCheck(SimpleCheckers.OwnerOnly())
+                    .Do(async e =>
+                    {
+                        DirectoryInfo di = new DirectoryInfo(NadekoBot.Config.MusicCache.Location + "/YouTube/");
+
+                        foreach (FileInfo file in di.GetFiles())
+                        {
+                            file.Delete();
+                        }
+
+                        di = new DirectoryInfo(NadekoBot.Config.MusicCache.Location + "/SoundCloud/");
+
+                        foreach (FileInfo file in di.GetFiles())
+                        {
+                            file.Delete();
+                        }
+                        await e.Channel.SendMessage("Master, I cleaned the cache folder for you:heart_exclamation: ").ConfigureAwait(false);
+                    });
+
+                cgb.CreateCommand(Prefix + "cachesize")
+                    .Description("Display the currect audio cache size")
+                    .AddCheck(SimpleCheckers.OwnerOnly())
+                    .Do(async e =>
+                    {
+                        DirectoryInfo di = new DirectoryInfo(NadekoBot.Config.MusicCache.Location);
+                        long size  = Helper.DirSize(di);
+                        await e.Channel.SendMessage("Master, my audio cache size is " +  Helper.BytesSizeToHumanReadable(size)).ConfigureAwait(false);
                     });
 
             });

--- a/NadekoBot/NadekoBot.csproj
+++ b/NadekoBot/NadekoBot.csproj
@@ -180,6 +180,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Classes\Helper.cs" />
     <Compile Include="Classes\ObservableConcurrentDictionary.cs" />
     <Compile Include="Modules\Administration\Commands\AutoAssignRole.cs" />
     <Compile Include="Modules\Administration\Commands\CustomReactionsCommands.cs" />

--- a/NadekoBot/_Models/JSONModels/Configuration.cs
+++ b/NadekoBot/_Models/JSONModels/Configuration.cs
@@ -89,6 +89,7 @@ namespace NadekoBot.Classes.JSONModels
         public bool ForwardToAllOwners { get; set; } = false;
         public bool IsRotatingStatus { get; set; } = false;
         public int BufferSize { get; set; } = 4.MiB();
+        public MusicCacheModel MusicCache { get; set; } = new MusicCacheModel();
 
         public string[] RaceAnimals { get; internal set; } = {
                 "🐼",
@@ -129,6 +130,9 @@ namespace NadekoBot.Classes.JSONModels
             {
                 CustomReactions = DefaultCustomReactions;
             }
+            Directory.CreateDirectory(MusicCache.Location); //Make sure that all the directories exist
+            Directory.CreateDirectory(MusicCache.Location + "/YouTube/");
+            Directory.CreateDirectory(MusicCache.Location + "/SoundCloud/");
         }
         [OnSerializing]
         internal void OnSerializing(StreamingContext context)
@@ -196,6 +200,13 @@ Nadeko Support Server: <https://discord.gg/0ehQwTK2RBjAxzEY>";
         public string Programming { get; set; } = "%";
         public string Pokemon { get; set; } = ">";
         public string Utility { get; set; } = ".";
+    }
+    
+    public class MusicCacheModel
+    {
+        public bool Enabled { get; set; } = true;
+        public long Size { get; set; } = 250.MiB();
+        public string Location { get; set; } = "cache/audio/";
     }
 
     public static class ConfigHandler

--- a/NadekoBot/bin/Debug/data/config_example.json
+++ b/NadekoBot/bin/Debug/data/config_example.json
@@ -4,6 +4,11 @@
   "ForwardToAllOwners": false,
   "IsRotatingStatus": false,
   "BufferSize": 4194304,
+  "MusicCache": {
+    "Enabled": true,
+    "Size": 262144000,
+    "Location": "cache/audio/"
+  },
   "RaceAnimals": [
     "🐼",
     "🐻",
@@ -134,5 +139,5 @@
   "CurrencySign": "🌸",
   "CurrencyName": "NadekoFlower",
   "DMHelpString": "Type `-h` for help.",
-  "HelpString": "You can use `{0}modules` command to see a list of all modules.\r\nYou can use `{0}commands ModuleName`\r\n(for example `{0}commands Administration`) to see a list of all of the commands in that module.\r\nFor a specific command help, use `{0}h \"Command name\"` (for example `-h \"!m q\"`)\r\n\r\n\r\n**LIST OF COMMANDS CAN BE FOUND ON THIS LINK**\r\n<https://github.com/Kwoth/NadekoBot/blob/master/commandlist.md>\r\n\r\n\r\nNadeko Support Server: <https://discord.gg/0ehQwTK2RBjAxzEY>"
+  "HelpString": "You can use `{0}modules` command to see a list of all modules.\nYou can use `{0}commands ModuleName`\n(for example `{0}commands Administration`) to see a list of all of the commands in that module.\nFor a specific command help, use `{0}h \"Command name\"` (for example `-h \"!m q\"`)\n\n\n**LIST OF COMMANDS CAN BE FOUND ON THIS LINK**\n<https://github.com/Kwoth/NadekoBot/blob/master/commandlist.md>\n\n\nNadeko Support Server: <https://discord.gg/0ehQwTK2RBjAxzEY>"
 }


### PR DESCRIPTION
I have added a basic audio cache from SoundCloud and YouTube, it can be deactivated with config file and have a specified max audio cache size.

When the cache has take all space available, it just stop caching new file, that's why it's a basic audio cache. He didn't check the last time it was played or how many times it was played.

Cached file are encoded with Opus codec and use video id from youtube/soundcloud for the filename and are stored in a user specified folder.

The cache system add new attributes in SongInfo that have default value for non Youtube/SoudCloud files, and they are not handled by the cache system (It would be stupid to cache and file that is already in the server). 

It would be pretty easy to add new provider to the cache system.

I have tested the audio cache in Windows and Ubuntu.