### PR TITLE
Update link to commands list

### DIFF
--- a/NadekoBot/_Models/JSONModels/Configuration.cs
+++ b/NadekoBot/_Models/JSONModels/Configuration.cs
@@ -192,7 +192,7 @@ For a specific command help, use `{0}h ""Command name""` (for example `-h ""!m q
 
 
 **LIST OF COMMANDS CAN BE FOUND ON THIS LINK**
-<https://github.com/Kwoth/NadekoBot/blob/master/commandlist.md>
+<http://nadekobot.readthedocs.io/en/latest/Commands%20List/>
 
 
 Nadeko Support Server: <https://discord.gg/0ehQwTK2RBjAxzEY>";


### PR DESCRIPTION
The default link you get when doing `-h` should now reference the command list on the docs, rather than the github wiki