### PR TITLE
Update Searches.cs to support gif avatars

### DIFF
--- a/src/NadekoBot/Modules/Searches/Searches.cs
+++ b/src/NadekoBot/Modules/Searches/Searches.cs
@@ -673,7 +673,15 @@ namespace NadekoBot.Modules.Searches
                 await channel.SendErrorAsync("Invalid user specified.").ConfigureAwait(false);
                 return;
             }
-            await channel.SendMessageAsync(await NadekoBot.Google.ShortenUrl(usr.AvatarUrl).ConfigureAwait(false)).ConfigureAwait(false);
+            
+            if (usr.AvatarId.Substring(0, 2) == "a_")
+            {
+                await channel.SendMessageAsync(await NadekoBot.Google.ShortenUrl("https://images.discordapp.net/avatars/" + usr.Id + "/" + usr.AvatarId + ".gif").ConfigureAwait(false)).ConfigureAwait(false);
+            }
+            else
+            {
+                await channel.SendMessageAsync(await NadekoBot.Google.ShortenUrl(usr.AvatarUrl).ConfigureAwait(false)).ConfigureAwait(false);
+            }
         }
 
         [NadekoCommand, Usage, Description, Aliases]


### PR DESCRIPTION
Gif avatars are now a feature of discord with discord nitro. 

All gif avatars' id start with "a_"

Check if the first characters of the string are a_ and if so, the url will be https://images.discordapp.net/avatars/[user id]/[avatar id].gif

If this is not the case, use the old method.