### PR TITLE
Updated regex for playlist, cleaned up regex fix earlier

### DIFF
--- a/src/NadekoBot/Services/Impl/GoogleApiService.cs
+++ b/src/NadekoBot/Services/Impl/GoogleApiService.cs
@@ -51,7 +51,7 @@ namespace NadekoBot.Services.Impl
             return (await query.ExecuteAsync()).Items.Select(i => i.Id.PlaylistId);
         }
 
-        private readonly Regex YtVideoIdRegex = new Regex(@"(?:youtube\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\?(?:\S*?&?v\=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})", RegexOptions.Compiled);
+        private readonly Regex YtVideoIdRegex = new Regex(@"(?:https?://)?(?:www\.)?(?:youtube\.com/watch\?v=([^&\n]+)|youtu\.be/([a-zA-Z\d_-]+))", RegexOptions.Compiled);
 
         public async Task<IEnumerable<string>> GetRelatedVideosAsync(string id, int count = 1)
         {

--- a/src/NadekoBot/Services/Impl/GoogleApiService.cs
+++ b/src/NadekoBot/Services/Impl/GoogleApiService.cs
@@ -38,7 +38,9 @@ namespace NadekoBot.Services.Impl
             if (count <= 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            var match = new Regex("(?:youtu\\.be\\/|list=)(?<id>[\\da-zA-Z\\-_]*)").Match(keywords);
+// a bit extra here so it accepts malformed playlist URL's. may throw error because it's expecting the contents after the ?list here, but we are allowing a full regex. although you get some boilerplate warnings, everything loads very quickly and properly.
+            
+            var match = new Regex(@"^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((?:\w|-){11})(?:&list=(\S+))?$").Match(keywords);
             if (match.Length > 1)
             {
                 return new[] { match.Groups["id"].Value.ToString() };
@@ -50,6 +52,7 @@ namespace NadekoBot.Services.Impl
 
             return (await query.ExecuteAsync()).Items.Select(i => i.Id.PlaylistId);
         }
+//proper regex that returns correct video IDs for normal youtube links every time
 
         private readonly Regex YtVideoIdRegex = new Regex(@"(?:https?://)?(?:www\.)?(?:youtube\.com/watch\?v=([^&\n]+)|youtu\.be/([a-zA-Z\d_-]+))", RegexOptions.Compiled);
 


### PR DESCRIPTION
- Regex from earlier is slightly cleaner. If you are using it to queue music just with `!!q`, you can use any YouTube keyword, any standard http/https YouTube URL, YouTube short URL's that contain a string of letters or `_` or `-` which wasn't the case in the earlier Google/YT API regex. And many of those short codes are still just strings of letters unlike the full URL's. So you can use: keywords, https://youtu.be/dQw4w9WgXcQ, or https://www.youtube.com/watch?v=dQw4w9WgXcQ (http or https) however & or other operators will show as wrong URL after the ID. That ensures that it is, again, only picking up the ID.

- Because of this one can also queue __seamlessly__ using the video ID:  `!!q dQw4w9WgXcQ` 

- Clean regex added for playlist. This is a _complete_ regex that will handle malformed playlist URL's, as well as most expressions. Because of this, using `!!playlist` (or `!!pl`) with a correctly formed playlist URL such as: https://www.youtube.com/playlist?list=PL4lEESSgxM_5O81EvKCmBIm_JT5Q7JeaI

will result in some verbose outputs every time the Google API cannot pull the track. In this way it is kind of good as it shows you an output every time it cannot get the playlist URL for any reason. **It is common, sort of out of control with massive queued playlists** but I tested it and only 20 or so weren't found out of close to 1,000.


- Again, you can very easily and cleanly (almost preferred) use the playlist ID (from above): `!!pl PL4lEESSgxM_5O81EvKCmBIm_JT5Q7JeaI` will work great

- You can of course use keywords `!!pl keywords` as usual; works just fine. Again any URL's in large queue's it cannot get it will output as verbose output (will ***not***) kill the bot session in any way. But it will let you know. 

----------

**TESTS DONE**

- [x] Queued multiple songs from SoundCloud and YouTube

- [x] Large playlist from YouTube (to the point of ratelimit!) - verified skipping `!!n` with a large amount, >300 -- this causes a bit of a delay but it is a very extreme example of using `!!n` to skip hundreds of songs in. Nadeko doesn't spam excessively either and deletes messages as expected.

- [x]  Verified moving songs in large queues (different positions), mixing a loaded playlist with a new playlist, removing and skipping. Also mixing in. 

- [x] Cleared queue using `!!stop` and immediately after reloaded - first with playlists, then repeating this while checking commands and regular music. Verified `!!destroy` (and subsequent re-queue) without restarting the bot. Finally, concluded with resuming `!!radio` stream, which I had going earlier for 8-12 hours on this codebase with no issues.  😄 


--------

(this does ***NOT** fix `!!ap` --> that issue was before any of this. I made a few changes locally but have to do more troubleshooting) 

