### PR TITLE
Fix specials characters for memegen

### DIFF
--- a/src/NadekoBot/Modules/Searches/Commands/MemegenCommands.cs
+++ b/src/NadekoBot/Modules/Searches/Commands/MemegenCommands.cs
@@ -6,12 +6,28 @@ using System.Linq;
 using System.Threading.Tasks;
 using NadekoBot.Attributes;
 using System.Net.Http;
+using System.Text;
 using NadekoBot.Extensions;
 
 namespace NadekoBot.Modules.Searches
 {
     public partial class Searches
     {
+
+        Dictionary<char, string> map = new Dictionary<char, string>();
+
+        public Searches()
+        {
+            map.Add('?', "~q");
+            map.Add('%', "~p");
+            map.Add('#', "~h");
+            map.Add('/', "~s");
+            map.Add(' ', "-");
+            map.Add('-', "--");
+            map.Add('_', "__");
+            map.Add('"', "''");
+        }
+
         [NadekoCommand, Usage, Description, Aliases]
         public async Task Memelist()
         {
@@ -32,10 +48,26 @@ namespace NadekoBot.Modules.Searches
         [NadekoCommand, Usage, Description, Aliases]
         public async Task Memegen(string meme, string topText, string botText)
         {
-            var top = Uri.EscapeDataString(topText.Replace(' ', '-'));
-            var bot = Uri.EscapeDataString(botText.Replace(' ', '-'));
+            var top = Replace(topText);
+            var bot = Replace(botText);
             await Context.Channel.SendMessageAsync($"http://memegen.link/{meme}/{top}/{bot}.jpg")
                          .ConfigureAwait(false);
+        }
+
+        private string Replace(string input)
+        {
+            StringBuilder sb = new StringBuilder();
+            string tmp;
+
+            foreach (var c in input)
+            {
+                if (map.TryGetValue(c, out tmp))
+                    sb.Append(tmp);
+                else
+                    sb.Append(c);
+            }
+
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
Using specials characters like ? or # cause the bot to post incorrect link. The link shouldn't URI encoded by the bot as discord do this on their end.

I wrote the replace function using https://github.com/jacebrowning/memegen as reference for specials characters.