### PR TITLE
Fix RepeatPlaylist/RepeatSong bug & add quote ID to .qsearch output

### DIFF
--- a/src/NadekoBot/Modules/Music/Classes/MusicControls.cs
+++ b/src/NadekoBot/Modules/Music/Classes/MusicControls.cs
@@ -163,7 +163,7 @@ namespace NadekoBot.Modules.Music.Classes
                         }
 
 
-                        if (RepeatPlaylist)
+                        if (RepeatPlaylist & !RepeatSong)
                             AddSong(CurrentSong, CurrentSong.QueuerName);
 
                         if (RepeatSong)

--- a/src/NadekoBot/Modules/Utility/Commands/QuoteCommands.cs
+++ b/src/NadekoBot/Modules/Utility/Commands/QuoteCommands.cs
@@ -97,7 +97,7 @@ namespace NadekoBot.Modules.Utility
                 if (keywordquote == null)
                     return;
 
-                await Context.Channel.SendMessageAsync("💬 " + keyword.ToLowerInvariant() + ":  " +
+                await Context.Channel.SendMessageAsync($"`#{keywordquote.Id}` 💬 " + keyword.ToLowerInvariant() + ":  " +
                                                        keywordquote.Text.SanitizeMentions());
             }
 


### PR DESCRIPTION

## Description
- Fixed RepeatPlaylist/RepeatSong bug that added the song multiple times/looped
- Added quote ID to the output of `.qsearch` per request of many 

## Tests
This was tested successfully and works in all cases (RepeatSong and RepeatPlaylist on, and them on and off individually). They work as intended.

`.qsearch` ID is self explanatory. 

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Update feature (non-breaking change which adds/updates functionality)


## Checklist:
- [x] All new and existing tests passed.