### PR TITLE
Add deny perm for addReactions on mute

### DIFF
--- a/src/NadekoBot/Services/Administration/MuteService.cs
+++ b/src/NadekoBot/Services/Administration/MuteService.cs
@@ -30,7 +30,7 @@ namespace NadekoBot.Services.Administration
         public event Action<IGuildUser, MuteType> UserMuted = delegate { };
         public event Action<IGuildUser, MuteType> UserUnmuted = delegate { };
 
-        private static readonly OverwritePermissions denyOverwrite = new OverwritePermissions(sendMessages: PermValue.Deny, attachFiles: PermValue.Deny);
+        private static readonly OverwritePermissions denyOverwrite = new OverwritePermissions(addReactions: PermValue.Deny, sendMessages: PermValue.Deny, attachFiles: PermValue.Deny);
 
         private readonly Logger _log = LogManager.GetCurrentClassLogger();
         private readonly DiscordSocketClient _client;


### PR DESCRIPTION
Added the permission for the channel override when muting to also include the denial of "addReactions." This is necessary since when muting it previously overwrote all channel perms(so it doesn't miss new channels,etc.) and there's no point in muting if they can still abuse reactions as well. 