### PR TITLE
Simple fix for laggy playback

### DIFF
--- a/src/NadekoBot/Modules/Music/Common/SongBuffer.cs
+++ b/src/NadekoBot/Modules/Music/Common/SongBuffer.cs
@@ -68,7 +68,7 @@ Check the guides for your platform on how to setup ffmpeg correctly:
                 Arguments = args,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = false,
                 CreateNoWindow = true,
             });
         }


### PR DESCRIPTION
This will fix laggy playback on single threaded systems when using Nadeko Audio. This has been tested for hours on multiple instances.