### PR TITLE
Fix for many of the 'double' spawn instances (reference #1747) [0/1 shard bots]

### DIFF
--- a/NadekoBot.Core/Modules/Administration/SelfCommands.cs
+++ b/NadekoBot.Core/Modules/Administration/SelfCommands.cs
@@ -276,6 +276,8 @@ namespace NadekoBot.Modules.Administration
                     JsonConvert.SerializeObject(_client.ShardId),
                     StackExchange.Redis.CommandFlags.FireAndForget);
                 await ReplyConfirmLocalized("shard_reconnecting", Format.Bold("#" + shardid)).ConfigureAwait(false);
+                await Task.Delay(6000).ConfigureAwait(false);
+                Environment.Exit(0);
             }
 
             [NadekoCommand, Usage, Description, Aliases]


### PR DESCRIPTION
**[This will work for anyone using a 0/1 shard bot, as that's all this tests for]** 

*I am sorry this is a long explanation but I wanted to be clear about it for others potentially reading.* 

So after a **lot** of going back and forth on #1747 - I was finally able to replicate the issue reliably. I used `.restartshard 0` to restart the shard, and it came back with two instances. Do it again and there were 3, etc. To make a long explanation short (much of it is in #1747 -- redis persists the data as it's still running after Nadeko restarts a shard. Even if you change the ShardsCoordinator to push a delete (like it does on `.die`) for the  `shardcoord_stats` table, that doesn't stop it. *And*, even after COMPLETELY killing every dotnet process and script, checking this multiple times, and restarting -- Nadeko would spawn an instance more than the last. Nothing worked. So there was an issue here. But:

### **tl;dr** -- It persists in redis, and the only way to kill it is to kill the running process for redis which you should do after stopping Nadeko (as Nadeko is writing to redis live) and then it will 'reset' and the restart will be smooth, as mentioned on my comments here: https://github.com/Kwoth/NadekoBot/issues/1747#issuecomment-345664265 

That explains most of my findings. But that fix of redis restart isn't a fix, only temporary, so the issue persists.

---

This seems to fix it. And I've confirmed it with doing **everything** I can many, many times. For example, I've done `.shardrestart 0` and it cleanly restarts the shard. I watch this with two console windows monitoring the dotnet processes and my pm2 process monitor which shows the realtime Nadeko logs, startup, etc. You will see that it will terminate and restart the shard properly. 

Now that **does not** confirm everything -- namely the ShardsCoordinator doing the auto-restart job without the extra spawns, so I went ahead and replicated a force-shard restart (from the ShardsCoordinator) - here's a normal output of `ps aux | grep dotnet`:

```sh
vlexar@node1:~/main/vlexar/$ sudo ps aux | grep dotnet
root     29449  2.2  0.2 3364388 78284 ?       SLl  12:50   0:00 dotnet run -c Release
root     29646  2.8  0.2 3349780 72940 ?       SLl  12:50   0:00 dotnet exec /home/vlexar/main/vlexar/NadekoBot/src/NadekoBot/bin/Release/netcoreapp2.0/NadekoBot.dll
root     29665  2.6  0.2 3364368 78660 ?       SLl  12:50   0:00 dotnet run -c Release -- 0 29646
root     29826 30.1  0.4 4171568 141436 ?      SLl  12:50   0:04 dotnet exec /home/vlexar/main/vlexar/NadekoBot/src/NadekoBot/bin/Release/netcoreapp2.0/NadekoBot.dll 0 29646
vlexar   30233  0.0  0.0  14244   996 pts/3    S+   12:50   0:00 grep --color=auto dotnet
```

Processes 29665/29826 are the child processes that are normal which are the ones that mimic the Shard. I went ahead and `kill -KILL 29665` / `kill -KILL 29826` to "force" Nadeko to act like it was restarting a shard. 

---

The bot went unresponsive to my commands (as it's a 0 shard bot so 100% normal/expected) for a few seconds.....but, after the proper 7.5 seconds or so (per ShardsCoordinator):

```bash
1|Nadeko   | -1 12:52:13 ShardsCoordinator | Shard 0 is scheduled for a restart because it's unresponsive.
1|Nadeko   | -1 12:52:19 ShardsCoordinator | Auto-restarting shard 0
```

And it came up 👍  I repeated this test **many** times, waiting different times in between. And I also did a few other ones: restarting Nadeko with `.die` then doing a `.restartshard 0` and *then* killing the child process to mimic the shard going down. And it does actually work *very* well, just like I'd expect. When I do the manual kill Shard 0 goes down, the bot is unresponsive for just a few seconds -- again, as it should be, but it comes back every time after a few seconds with the scheduled auto-restart. 

---
And there is nothing that is active and running that's consuming resources that are leftover; the process is killed with `Environment.Exit(0);` and confirmed to work. 

It's just two lines of a fix, so I apologize  for the long explanation, but I wanted to be clear about how I came to this. This wasn't even an issue that affected me, but after a lot of trial and error I was able to replicate it and then come to this.

