### PR TITLE
Reformatted OSX

### DIFF
--- a/docs/guides/OSX Guide.md
+++ b/docs/guides/OSX Guide.md
@@ -1,17 +1,13 @@
 ## Setting Up NadekoBot on OSX (macOS)
 
 #### Prerequisites 
-- [Homebrew][Homebrew]
-- [Google Account](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/#setting-up-your-api-keys)
-- Text Editor (TextWrangler, or equivalent) or outside editor such as [Atom][Atom]
+- [Homebrew](http://brew.sh/). Install it with `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"` or update it with `brew update`.
+- Text Editor (TextWrangler, or equivalent) or outside editor such as [Atom](https://atom.io/)
+- [Create Discord Bot application](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/#creating-discord-bot-application) and [Invite the bot to your server](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/#inviting-your-bot-to-your-server). 
 
-#### Installing Homebrew
+**Installing dependencies with Homebrew**
 
-```/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"```
-
-Run `brew update` to fetch the latest package data.  
-
-#### Installing dependencies
+In terminal:
 ```
 brew install wget
 brew install git
@@ -30,132 +26,85 @@ brew install redis
 brew services start redis
 ```
 
-#### Installing .NET Core SDK
+**Installing .NET Core SDK**
 
 - `ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/`
 - `ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/`
-- Download the [.NET Core SDK][.NET Core SDK]
+- Download the [.NET Core SDK](https://www.microsoft.com/net/core#macos)
 - Open the `.pkg` file you downloaded and install it.
 - `ln -s /usr/local/share/dotnet/dotnet /usr/local/bin`
 
-#### Check your `FFMPEG`
+**Installing xcode-select**
 
-**In case your `FFMPEG` wasnt installed properly (Optional)**
+- `xcode-select --install`
 
+A dialog box will open asking if you want to install `xcode-select`. Select install and finish the installation.
+
+#### Getting Nadeko Ready to Run
+
+`cd ~ && wget -N https://github.com/Kwoth/NadekoBot-BashScript/raw/1.9/linuxAIO.sh && bash linuxAIO.sh`
+Choose `1. Download NadekoBot`
+Once Installation is completed you should see the options again.	
+
+Find and edit the `credentials.json` according to this [guide](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/#setting-up-credentialsjson-file).
+
+Choose `6` (exit) if you would like to pause. Otherwise, continue. 
+
+#### Running NadekoBot
+
+If you aren't seeing the six options in terminal, run `cd ~ && wget -N https://github.com/Kwoth/NadekoBot-BashScript/raw/1.9/linuxAIO.sh && bash linuxAIO.sh`.
+
+**The options:**
+`2. Run Nadeko (Normally)`
+
+If you shut down the bot with `.die`, it will stay offline until you manually run it again.
+
+`3. Run Nadeko with Auto Restart`
+
+If you shut down the bot with `.die`, it will stay restart automatically. To stop the bot, stop the bot proccess (close terminal)
+
+Option 3 will show you some more options: 
+
+- `1. Run Auto Restart normally without Updating.`: Bot will restart on `die` command and will not be downloading the latest build available.
+- `2. Run Auto Restart and update NadekoBot.` Bot will restart and download the latest build available everytime `die` command is used.
+
+#### Running with terminal closed
+**Create a new Session:**
+
+`tmux new -s nadeko`  
+This will create a new session named `nadeko` *(you can replace “nadeko” with anything you prefer, as long as you remember  your session name)*
+
+Run the bot in this session.
+Detatch the session: `^b d`
+
+**Attatching a detatched session**
+`tmux a -t nadeko`
+
+**Remember** that while running with Auto Restart, closing the terminal won't stop the bot proccess. To stop the bot from terminal:
+`tmux kill-session -t nadeko`
+
+#### Updating Nadeko
+
+- Stop the bot, and make sure it is not running.
+- Create a new tmux session if you are using tmux.
+- `cd ~ && wget -N https://github.com/Kwoth/NadekoBot-BashScript/raw/1.9/linuxAIO.sh && bash linuxAIO.sh`
+- Choose `1` to update the bot with latest build available.
+- Choose `2` or `3` to run the bot again.
+
+#### Doing a clean reinstall
+
+- Make a backup of your credentials (`~/NadekoBot/src/NadekoBot/credentials.json`)
+- Make a backup of the database (`~/NadekoBot/src/NadekoBot/bin/Release/netcoreapp2.0/data/NadekoBot.db`)
+- Delete the NadekoBot folder
+- Reinstall, replace the files you backed up, and run.
+
+#### Help! My music isn't working!
+
+Make sure you have the [Google API Key](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/#setting-up-your-api-keys) in your `credentials.json`
+If music still isn't working, try reinstalling ffmpeg:
 - `brew options ffmpeg`
 - `brew install ffmpeg --with-x --with-y --with-z` etc.
 - `brew update && brew upgrade` (Update formulae and Homebrew itself && Install newer versions of outdated packages)
 - `brew prune` (Remove dead symlinks from Homebrew’s prefix)
 - `brew doctor` (Check your Homebrew installation for common issues)
 - Then try `brew install ffmpeg` again.
-
-#### Installing xcode-select
-
-Xcode command line tools. You will do this in Terminal.app by running the following command line:
-
-`xcode-select --install`
-
-A dialog box will open asking if you want to install `xcode-select`. Select install and finish the installation.
-
-#### Downloading and building Nadeko
-
-Use the following command to get and run `linuxAIO.sh`:		
-(Remember **DO NOT** rename the file `linuxAIO.sh`)
-
-`cd ~ && wget -N https://github.com/Kwoth/NadekoBot-BashScript/raw/1.9/linuxAIO.sh && bash linuxAIO.sh`
-
-Follow the on screen instructions:
-
-Choose `1. Download NadekoBot` To Get the latest build. (most recent updates)
-
-Once Installation is completed you should see the options again.	
-Next, choose `6` to exit. 
-
-#### Creating and Inviting bot
-
-- Read here [how to create a Discord Bot application and invite it.](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/#creating-discord-bot-application)
- 
-#### Setting up Credentials.json file
-- Open up the `NadekoBot` folder, which should be in your home directory, then `NadekoBot` folder then `src` folder and then the additonal `NadekoBot` folder.
-- Edit the way its guided here: [Setting up credentials.json](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/#setting-up-credentialsjson-file)
-- **If** you already have Nadeko 1.x setup and have `credentials.json` and `NadekoBot.db`, you can just copy and paste the `credentials.json` to `NadekoBot/src/NadekoBot` and `NadekoBot.db` to `NadekoBot/src/NadekoBot/bin/Release/netcoreapp2.0/data`.			
-**Or** follow the [Upgrading Guide.](http://nadekobot.readthedocs.io/en/latest/guides/Upgrading%20Guide/)
-
-#### Setting NadekoBot Music
-
-For Music Setup and API keys check [Setting up NadekoBot for Music](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/#setting-up-your-api-keys) and [JSON Explanations](http://nadekobot.readthedocs.io/en/latest/JSON%20Explanations/).
-
-#### Running NadekoBot
-
-**Create a new Session:**
-
-- Using Screen			
-
-`screen -S nadeko`
- 
-- Using tmux			
-
-`tmux new -s nadeko`  
-  
-The above command will create a new session named **nadeko** *(you can replace “nadeko” with anything you prefer and remember its your session name)* so you can run the bot in background without having to keep the PuTTY running.
-
-**Next, we need to run `linuxAIO.sh` in order to get the latest running scripts with patches:**
-
-- `cd ~ && wget -N https://github.com/Kwoth/NadekoBot-BashScript/raw/1.9/linuxAIO.sh && bash linuxAIO.sh`
-
-**From the options,**
-
-Choose `2` to **Run NadekoBot normally.**		
-**NOTE:** With option `2` (Running normally), if you use `.die` [command](http://nadekobot.readthedocs.io/en/latest/Commands%20List/#administration) in discord. The bot will shut down and will stay offline until you manually run it again. (best if you want to check the bot.)
-
-Choose `3` to **Run NadekoBot with Auto Restart.**	
-**NOTE:** With option `3` (Running with Auto Restart), bot will auto run if you use `.die` [command](http://nadekobot.readthedocs.io/en/latest/Commands%20List/#administration) making the command `.die` to function as restart.	
-
-It will show you the following options: 
-```
-1. Run Auto Restart normally without Updating.
-2. Run Auto Restart and update NadekoBot.
-3. Exit
-```
-
-- With option `1. Run Auto Restart normally without Updating.` Bot will restart on `die` command and will not be downloading the latest build available.
-- With option `2. Run Auto Restart and update NadekoBot.` Bot will restart and download the latest build of bot available everytime `die` command is used.
-
-**Remember** that, while running with Auto Restart, you will need to [close the tmux session](http://nadekobot.readthedocs.io/en/latest/guides/Linux%20Guide/#restarting-nadeko) to stop the bot completely.
-
-
-Now time to move bot to background and to do that, press CTRL+B,D (this will detach the nadeko session using TMUX)	
-If you used Screen press CTRL+A+D (this will detach the nadeko screen) 
-
-#### Updating Nadeko
-
-- Connect to the terminal.
-- `tmux kill-session -t nadeko` [(don't forget to replace **nadeko** in the command to what ever you named your bot's session)](http://nadekobot.readthedocs.io/en/latest/guides/OSX%20Guide/#some-more-info)
-- Make sure the bot is **not** running.
-- `tmux new -s nadeko` (**nadeko** is the name of the session)
-- `cd ~ && wget -N https://github.com/Kwoth/NadekoBot-BashScript/raw/1.9/linuxAIO.sh && bash linuxAIO.sh`
-- Choose `1` to update the bot with **latest build** available.
-- Next, choose either `2` or `3` to run the bot again with **normally** or **auto restart** respectively.
-- Done.
-
-#### Some more Info
-
-**TMUX**
-
-- If you want to see the sessions after logging back again, type `tmux ls`, and that will give you the list of sessions running. 
-- If you want to switch to/ see that session, type `tmux a -t nadeko` (nadeko is the name of the session we created before so, replace `nadeko` with the session name you created.)
-- If you want to kill NadekoBot session, type `tmux kill-session -t nadeko`
-
-**Screen**
-
-- If you want to see the sessions after logging back again, type `screen -ls`, and that will give you the list of screens. 
-- If you want to switch to/ see that screen, type `screen -r nadeko` (nadeko is the name of the screen we created before so, replace `nadeko` with the screen name you created.)
-- If you want to kill the NadekoBot screen, type `screen -X -S nadeko quit`
-
-[Homebrew]: http://brew.sh/
-[.NET Core SDK]: https://www.microsoft.com/net/core#macos
-[DiscordApp]: https://discordapp.com/developers/applications/me
-[Atom]: https://atom.io/
-[Invite Guide]: http://discord.kongslien.net/guide.html
-[Google Console]: https://console.developers.google.com
-[Soundcloud]: https://soundcloud.com/you/apps/new


### PR DESCRIPTION
Removed google account from prereqs
Moved homebrew installation cmds to prereqs
Moved discord application setup to prereqs
Moved the manual update (from 1.x) to manual updates
Deleted music section; explained in json explanations.
Moved checking ffmpeg to bottom
Moved running the bot out from tmux and into a new category for running the bot
Made a section for tmux
Deleted screen bc theres no point in confusing ppl with two options
deleted some extra info that shouldnt be a problem (like dont rename linuxaio.sh, run these commands in terminal.app, etc)