### PR TITLE
 Fixed calculation of VoiceChannel count

### DIFF
--- a/NadekoBot.Core/Services/Impl/StatsService.cs
+++ b/NadekoBot.Core/Services/Impl/StatsService.cs
@@ -198,7 +198,7 @@ namespace NadekoBot.Core.Services.Impl
         {
             var guilds = _client.Guilds.ToArray();
             _textChannels = guilds.Sum(g => g.Channels.Count(cx => cx is ITextChannel));
-            _voiceChannels = guilds.Sum(g => g.Channels.Count) - _textChannels;
+            _voiceChannels = guilds.Sum(g => g.Channels.Count(cx => cx is IVoiceChannel));
         }
 
         public Task<string> Print()


### PR DESCRIPTION
Since categories were introduced, the number of voice channels was too large as it also contained the number of categories. (by Anheledir#6792)