### PR TITLE
Add count replacement ("searches_streams_cleared")

### DIFF
--- a/NadekoBot.Core/Modules/Searches/StreamNotificationCommands.cs
+++ b/NadekoBot.Core/Modules/Searches/StreamNotificationCommands.cs
@@ -144,7 +144,7 @@ namespace NadekoBot.Modules.Searches
             public async Task StreamsClear()
             {
                 var count = _service.ClearAllStreams(Context.Guild.Id);
-                await ReplyConfirmLocalized("streams_cleared").ConfigureAwait(false);
+                await ReplyConfirmLocalized("streams_cleared", count).ConfigureAwait(false);
             }
 
             [NadekoCommand, Usage, Description, Aliases]


### PR DESCRIPTION
POEditor string:
"All {0} followed streams on this server have been removed."
Function stores count var.
All makes it seem like the bot should be using count as a replacement.