### PR TITLE
Add OkColor to .lsar

### DIFF
--- a/NadekoBot.Core/Modules/Administration/SelfAssignedRolesCommands.cs
+++ b/NadekoBot.Core/Modules/Administration/SelfAssignedRolesCommands.cs
@@ -129,7 +129,7 @@ namespace NadekoBot.Modules.Administration
                         }
                     }
 
-                    return new EmbedBuilder()
+                    return new EmbedBuilder().WithOkColor()
                         .WithTitle(Format.Bold(GetText("self_assign_list", roles.Count())))
                         .WithDescription(rolesStr.ToString())
                         .WithFooter(exclusive


### PR DESCRIPTION
Add the OkColor back to .lsar because after the Update the Color is gone.
Before:
![lsarbefore](https://user-images.githubusercontent.com/24619854/39672467-df9c26a2-512a-11e8-9496-e65060eb9941.png)
And after:
![lsarafter](https://user-images.githubusercontent.com/24619854/39672468-e3f13ec2-512a-11e8-9ec5-50b92a8d3efa.png)

Also yay my first PR 😂 