### PR TITLE
add utf-8 support for non-english langs google searchs

### DIFF
--- a/NadekoBot.Core/Modules/Searches/Searches.cs
+++ b/NadekoBot.Core/Modules/Searches/Searches.cs
@@ -450,7 +450,7 @@ namespace NadekoBot.Modules.Searches
         public async Task Google([Remainder] string terms = null)
         {
             var oterms = terms?.Trim();
-            if (string.IsNullOrWhiteSpace(terms))
+            if (string.IsNullOrWhiteSpace(oterms))
                 return;
 
             terms = WebUtility.UrlEncode(oterms).Replace(' ', '+');

--- a/NadekoBot.Core/Modules/Searches/Searches.cs
+++ b/NadekoBot.Core/Modules/Searches/Searches.cs
@@ -449,13 +449,13 @@ namespace NadekoBot.Modules.Searches
         [NadekoCommand, Usage, Description, Aliases]
         public async Task Google([Remainder] string terms = null)
         {
-            terms = terms?.Trim();
+            var oterms = terms?.Trim();
             if (string.IsNullOrWhiteSpace(terms))
                 return;
 
-            terms = WebUtility.UrlEncode(terms).Replace(' ', '+');
+            terms = WebUtility.UrlEncode(oterms).Replace(' ', '+');
 
-            var fullQueryLink = $"https://www.google.ca/search?q={ terms }&safe=on&lr=lang_eng&hl=en";
+            var fullQueryLink = $"https://www.google.ca/search?q={ terms }&safe=on&lr=lang_eng&hl=en&ie=utf-8&oe=utf-8";
 
             using (var msg = new HttpRequestMessage(HttpMethod.Get, fullQueryLink))
             {
@@ -493,7 +493,7 @@ namespace NadekoBot.Modules.Searches
 
                     var embed = new EmbedBuilder()
                         .WithOkColor()
-                        .WithAuthor(eab => eab.WithName(GetText("search_for") + " " + terms.TrimTo(50))
+                        .WithAuthor(eab => eab.WithName(GetText("search_for") + " " + oterms.TrimTo(50))
                             .WithUrl(fullQueryLink)
                             .WithIconUrl("http://i.imgur.com/G46fm8J.png"))
                         .WithTitle(Context.User.ToString())

--- a/NadekoBot.Core/Modules/Searches/Searches.cs
+++ b/NadekoBot.Core/Modules/Searches/Searches.cs
@@ -363,13 +363,13 @@ namespace NadekoBot.Modules.Searches
         [NadekoCommand, Usage, Description, Aliases]
         public async Task RandomImage([Remainder] string terms = null)
         {
-            terms = terms?.Trim();
-            if (string.IsNullOrWhiteSpace(terms))
+            var oterms = terms?.Trim();
+            if (string.IsNullOrWhiteSpace(oterms))
                 return;
-            terms = WebUtility.UrlEncode(terms).Replace(' ', '+');
+            terms = WebUtility.UrlEncode(oterms).Replace(' ', '+');
             try
             {
-                var res = await _google.GetImageAsync(terms, new NadekoRandom().Next(0, 50)).ConfigureAwait(false);
+                var res = await _google.GetImageAsync(oterms, new NadekoRandom().Next(0, 50)).ConfigureAwait(false);
                 var embed = new EmbedBuilder()
                     .WithOkColor()
                     .WithAuthor(eab => eab.WithName(GetText("image_search_for") + " " + terms.TrimTo(50))
@@ -383,7 +383,6 @@ namespace NadekoBot.Modules.Searches
             catch
             {
                 _log.Warn("Falling back to Imgur");
-                terms = WebUtility.UrlEncode(terms).Replace(' ', '+');
 
                 var fullQueryLink = $"http://imgur.com/search?q={ terms }";
                 var config = Configuration.Default.WithDefaultLoader();

--- a/NadekoBot.Core/Modules/Searches/Searches.cs
+++ b/NadekoBot.Core/Modules/Searches/Searches.cs
@@ -308,18 +308,18 @@ namespace NadekoBot.Modules.Searches
         [NadekoCommand, Usage, Description, Aliases]
         public async Task Image([Remainder] string terms = null)
         {
-            terms = terms?.Trim();
-            if (string.IsNullOrWhiteSpace(terms))
+            var oterms = terms?.Trim();
+            if (string.IsNullOrWhiteSpace(oterms))
                 return;
 
-            terms = WebUtility.UrlEncode(terms).Replace(' ', '+');
+            terms = WebUtility.UrlEncode(oterms).Replace(' ', '+');
 
             try
             {
-                var res = await _google.GetImageAsync(terms).ConfigureAwait(false);
+                var res = await _google.GetImageAsync(oterms).ConfigureAwait(false);
                 var embed = new EmbedBuilder()
                     .WithOkColor()
-                    .WithAuthor(eab => eab.WithName(GetText("image_search_for") + " " + terms.TrimTo(50))
+                    .WithAuthor(eab => eab.WithName(GetText("image_search_for") + " " + oterms.TrimTo(50))
                         .WithUrl("https://www.google.rs/search?q=" + terms + "&source=lnms&tbm=isch")
                         .WithIconUrl("http://i.imgur.com/G46fm8J.png"))
                     .WithDescription(res.Link)

--- a/NadekoBot.Core/Modules/Searches/Searches.cs
+++ b/NadekoBot.Core/Modules/Searches/Searches.cs
@@ -402,7 +402,7 @@ namespace NadekoBot.Modules.Searches
 
                     var embed = new EmbedBuilder()
                         .WithOkColor()
-                        .WithAuthor(eab => eab.WithName(GetText("image_search_for") + " " + terms.TrimTo(50))
+                        .WithAuthor(eab => eab.WithName(GetText("image_search_for") + " " + oterms.TrimTo(50))
                             .WithUrl(fullQueryLink)
                             .WithIconUrl("http://s.imgur.com/images/logo-1200-630.jpg?"))
                         .WithDescription(source)

--- a/NadekoBot.Core/Modules/Searches/Searches.cs
+++ b/NadekoBot.Core/Modules/Searches/Searches.cs
@@ -349,7 +349,7 @@ namespace NadekoBot.Modules.Searches
 
                     var embed = new EmbedBuilder()
                         .WithOkColor()
-                        .WithAuthor(eab => eab.WithName("Image Search For: " + terms.TrimTo(50))
+                        .WithAuthor(eab => eab.WithName("Image Search For: " + oterms.TrimTo(50))
                             .WithUrl(fullQueryLink)
                             .WithIconUrl("http://s.imgur.com/images/logo-1200-630.jpg?"))
                         .WithDescription(source)
@@ -372,7 +372,7 @@ namespace NadekoBot.Modules.Searches
                 var res = await _google.GetImageAsync(oterms, new NadekoRandom().Next(0, 50)).ConfigureAwait(false);
                 var embed = new EmbedBuilder()
                     .WithOkColor()
-                    .WithAuthor(eab => eab.WithName(GetText("image_search_for") + " " + terms.TrimTo(50))
+                    .WithAuthor(eab => eab.WithName(GetText("image_search_for") + " " + oterms.TrimTo(50))
                         .WithUrl("https://www.google.rs/search?q=" + terms + "&source=lnms&tbm=isch")
                         .WithIconUrl("http://i.imgur.com/G46fm8J.png"))
                     .WithDescription(res.Link)

--- a/NadekoBot.Core/Modules/Searches/Searches.cs
+++ b/NadekoBot.Core/Modules/Searches/Searches.cs
@@ -349,7 +349,7 @@ namespace NadekoBot.Modules.Searches
 
                     var embed = new EmbedBuilder()
                         .WithOkColor()
-                        .WithAuthor(eab => eab.WithName("Image Search For: " + oterms.TrimTo(50))
+                        .WithAuthor(eab => eab.WithName(GetText("image_search_for") + " " + oterms.TrimTo(50))
                             .WithUrl(fullQueryLink)
                             .WithIconUrl("http://s.imgur.com/images/logo-1200-630.jpg?"))
                         .WithDescription(source)


### PR DESCRIPTION
added query params `ie` & `oe` to force utf-8 treatment, also embed title changed
it will print the original search terms (this avoid the annoying percent-encoding
related to non-english langs)

![before vs after](https://i.imgur.com/cog3XWA.png)