### PR TITLE
Allow for 0 values of TriviaCurrencyReward

### DIFF
--- a/NadekoBot.Core/Services/Impl/BotConfigProvider.cs
+++ b/NadekoBot.Core/Services/Impl/BotConfigProvider.cs
@@ -90,7 +90,7 @@ namespace NadekoBot.Core.Services.Impl
                             return false;
                         break;
                     case BotConfigEditType.TriviaCurrencyReward:
-                        if (int.TryParse(newValue, out var triviaReward) && triviaReward > 0)
+                        if (int.TryParse(newValue, out var triviaReward) && triviaReward >= 0)
                             bc.TriviaCurrencyReward = triviaReward;
                         else
                             return false;


### PR DESCRIPTION
Default value is 0 anyway.
Should be allowed to set it back to 0 if decided the feature is no longer wanted.
At the moment, tryParse && triviaReward > 0 is blocking that