### PR TITLE
Fixed .videocall not checking for duplicates, fixes #2452

### DIFF
--- a/NadekoBot.Core/Modules/Searches/Searches.cs
+++ b/NadekoBot.Core/Modules/Searches/Searches.cs
@@ -784,7 +784,7 @@ namespace NadekoBot.Modules.Searches
         public async Task Videocall(params IGuildUser[] users)
         {
             var allUsrs = users.Append(Context.User);
-            var allUsrsArray = allUsrs.ToArray();
+            var allUsrsArray = allUsrs.Distinct().ToArray();
             var str = allUsrsArray.Aggregate("http://appear.in/", (current, usr) => current + Uri.EscapeUriString(usr.Username[0].ToString()));
             str += new NadekoRandom().Next();
             foreach (var usr in allUsrsArray)


### PR DESCRIPTION
Prevents users from passing a single user as multiple arguments, resulting in the bot DM spamming them.