### PR TITLE
Added a simple .invite command.

### DIFF
--- a/NadekoBot.Core/Modules/Help/Help.cs
+++ b/NadekoBot.Core/Modules/Help/Help.cs
@@ -243,6 +243,14 @@ namespace NadekoBot.Modules.Help
             await ReplyConfirmLocalized("donate", PatreonUrl, PaypalUrl).ConfigureAwait(false);
         }
 
+        [NadekoCommand, Usage, Description, Aliases]
+        public async Task Invite()
+        {
+            var InviteLink = ($"https://discordapp.com/oauth2/authorize?scope=bot&client_id={_creds.ClientId}&permissions=66186303");
+            await ReplyConfirmLocalized("invite", InviteLink).ConfigureAwait(false);
+        }
+
+
         private string GetRemarks(string[] arr)
         {
             return string.Join(" or ", arr.Select(x => Format.Code(x)));

--- a/src/NadekoBot/_strings/ResponseStrings.en-US.json
+++ b/src/NadekoBot/_strings/ResponseStrings.en-US.json
@@ -974,5 +974,5 @@
   "searches_distance": "Distance between {0} and {1} is {2}km",
   "gambling_bot_list_awarded": "Awarded {0} to {1} users!",
   "administration_updates_check_set": "Checking for updates have been set to {0}.",
-  "help_invite": "Invite me using this link:\n{0}\nThank you! ♥"
+  "help_invite": "invite me using this link:\n{0}\nThank you! ♥"
 }

--- a/src/NadekoBot/_strings/ResponseStrings.en-US.json
+++ b/src/NadekoBot/_strings/ResponseStrings.en-US.json
@@ -973,5 +973,6 @@
   "xp_reset_server": "XP of all users on the server has been reset.",
   "searches_distance": "Distance between {0} and {1} is {2}km",
   "gambling_bot_list_awarded": "Awarded {0} to {1} users!",
-  "administration_updates_check_set": "Checking for updates have been set to {0}."
+  "administration_updates_check_set": "Checking for updates have been set to {0}.",
+  "help_invite": "Invite me using this link:\n{0}\nThank you! ♥"
 }

--- a/src/NadekoBot/_strings/cmd/command_strings.json
+++ b/src/NadekoBot/_strings/cmd/command_strings.json
@@ -21,6 +21,14 @@
       "{0}donate"
     ]
   },
+  "invite": {
+    "Cmd": "invite inv",
+    "Desc": "Sends an Invite link to your current channel.",
+    "Usage": [
+      "{0}invite",
+      "{0}inv"
+    ]
+  },
   "modules": {
     "Cmd": "modules mdls",
     "Desc": "Lists all bot modules.",


### PR DESCRIPTION
Hi, I've made a simple .invite command, which uses the given ClientID from the Crendentials, so selfhosts should work too.

I also added the command string and output string to the JSON's. The translators can use the `{0}` for the Invite link. 

It looks like this right now:
![image](https://user-images.githubusercontent.com/24619854/43573308-b7dffeac-9641-11e8-9bfe-6f24bc144e06.png)

If it's unneeded or useless, just close this PR. 😃 
Have a nice day!