### PR TITLE
Exception when no input console

### DIFF
--- a/NadekoBot.Core/Services/Impl/BotCredentials.cs
+++ b/NadekoBot.Core/Services/Impl/BotCredentials.cs
@@ -65,7 +65,8 @@ namespace NadekoBot.Core.Services.Impl
                 if (string.IsNullOrWhiteSpace(Token))
                 {
                     _log.Error("Token is missing from credentials.json or Environment varibles. Add it and restart the program.");
-                    Console.ReadKey();
+                    if (!Console.IsInputRedirected)
+                        Console.ReadKey();
                     Environment.Exit(3);
                 }
                 OwnerIds = data.GetSection("OwnerIds").GetChildren().Select(c => ulong.Parse(c.Value)).ToImmutableArray();

--- a/NadekoBot.Core/Services/NadekoBot.cs
+++ b/NadekoBot.Core/Services/NadekoBot.cs
@@ -370,7 +370,8 @@ namespace NadekoBot
             catch
             {
                 _log.Error("You must run the application as an ADMINISTRATOR.");
-                Console.ReadKey();
+                if (!Console.IsInputRedirected)
+                    Console.ReadKey();
                 Environment.Exit(2);
             }
         }


### PR DESCRIPTION
When Nadeko is run by Docker (in my case but not limited to), their is no interactive input console.
When there is a fatal configuration error, the application exists with a Console.ReadKey().
This is OK during a debug session but throw an InvalidOperationException on other situations.