### PR TITLE
Embed footer's icon_url fix?

### DIFF
--- a/NadekoBot.Core/Common/Replacements/Replacer.cs
+++ b/NadekoBot.Core/Common/Replacements/Replacer.cs
@@ -58,6 +58,7 @@ namespace NadekoBot.Common.Replacements
 
             if (embedData.Footer != null)
                 embedData.Footer.Text = Replace(embedData.Footer.Text);
+                embedData.Footer.IconUrl = Replace(embedData.Footer.IconUrl);
         }
     }
 }


### PR DESCRIPTION
Possible fix for issue #2544 
Before:
![image](https://user-images.githubusercontent.com/24619854/44790971-ddda7a00-aba0-11e8-9396-5605cc84f764.png)
And after:
![image](https://user-images.githubusercontent.com/24619854/44790976-e3d05b00-aba0-11e8-95f7-f6faa5a9284b.png)
