### PR TITLE
Fix for servers with a lot of long emoji names

### DIFF
--- a/NadekoBot.Core/Modules/Utility/InfoCommands.cs
+++ b/NadekoBot.Core/Modules/Utility/InfoCommands.cs
@@ -68,7 +68,8 @@ namespace NadekoBot.Modules.Utility
                         .WithValue(string.Join(" ", guild.Emotes
                             .Shuffle()
                             .Take(20)
-                            .Select(e => $"{e.Name} {e.ToString()}"))));
+                            .Select(e => $"{e.Name} {e.ToString()}"))
+                            .TrimTo(1020)));
                 }
                 await Context.Channel.EmbedAsync(embed).ConfigureAwait(false);
             }


### PR DESCRIPTION
This caused the following exception on one of my servers:
System.ArgumentException: Field value length must be less than or
equal to 1024.