### PR TITLE
Fix youtube videoid

### DIFF
--- a/NadekoBot.Core/Services/Impl/Ytdl.cs
+++ b/NadekoBot.Core/Services/Impl/Ytdl.cs
@@ -15,6 +15,11 @@ namespace NadekoBot.Core.Services.Impl
 
         public async Task<string> GetDataAsync(string url)
         {
+            // escape the minus on the video argument
+            // to prevent youtube-dl to handle it like an argument
+            if (url != null && url.StartsWith("-"))
+                url = '\\' + url;
+
             using (Process process = new Process()
             {
                 StartInfo = new ProcessStartInfo()

--- a/NadekoBot.Core/Services/Impl/Ytdl.cs
+++ b/NadekoBot.Core/Services/Impl/Ytdl.cs
@@ -28,6 +28,8 @@ namespace NadekoBot.Core.Services.Impl
                 },
             })
             {
+                _log.Debug($"Executing {process.StartInfo.FileName} {process.StartInfo.Arguments}");
+
                 process.Start();
                 var str = await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
                 var err = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);


### PR DESCRIPTION
Some Youtube video's id starts with a minus.
Given to youtube-dl without escaping, it handles the video id as a switch.

Sample: https://www.youtube.com/watch?v=-5DyDpdBW3A

I had to add a debug line, that in my sense should not be removed to better understand stack traces but be controlled by the nlog conf (PR incoming).