### PR TITLE
Fix to the "docker-compose.yml" broken link on the Docker Guide

### DIFF
--- a/NadekoBot.Core/NadekoBot.Core.csproj
+++ b/NadekoBot.Core/NadekoBot.Core.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.9.10" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00940" />
+    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00937" />
     <PackageReference Include="CoreCLR-NCalc" Version="2.2.34" />
     <PackageReference Include="Google.Apis.Urlshortener.v1" Version="1.35.1.138" />
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.35.1.1226" />

--- a/NadekoBot.Core/NadekoBot.Core.csproj
+++ b/NadekoBot.Core/NadekoBot.Core.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.9.10" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00937" />
+    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00940" />
     <PackageReference Include="CoreCLR-NCalc" Version="2.2.34" />
     <PackageReference Include="Google.Apis.Urlshortener.v1" Version="1.35.1.138" />
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.35.1.1226" />

--- a/docs/guides/Docker Guide.md
+++ b/docs/guides/Docker Guide.md
@@ -41,7 +41,7 @@ docker rm _nadeko
 ## Start the bot
 
 - Creates an empty folder. It will contain all Nadeko's data, including the credentials.json
-- Download the file [docker-compose.yml](https://raw.githubusercontent.com/Kwoth/NadekoBot/1.9/Dockerfile/docker-compose.yml) and place it on the previously created folder.
+- Download the file [docker-compose.yml](https://raw.githubusercontent.com/Kwoth/NadekoBot/1.9/docker-compose.yml) and place it on the previously created folder.
 - Edit the `docker-compose.yml` by uncommenting the line `image:` and commenting the line `build:`
 - Put your credentials.json in this folder
 - Open a command line, go to the folder with this command line: `cd "your_folder"`


### PR DESCRIPTION
This fixes a broken link on the [Docker Guide](https://nadekobot.readthedocs.io/en/latest/guides/Docker%20Guide/)
![image](https://user-images.githubusercontent.com/1812311/46269045-bd416f00-c514-11e8-9607-ea2dd7715d30.png)

This link currently leads to:
https://raw.githubusercontent.com/Kwoth/NadekoBot/1.9/Dockerfile/docker-compose.yml

After this commit, it will lead to:
https://raw.githubusercontent.com/Kwoth/NadekoBot/1.9/docker-compose.yml