### PR TITLE
upgrade discord.net package to >2.0.0-beta2-00944

### DIFF
--- a/NadekoBot.Core/NadekoBot.Core.csproj
+++ b/NadekoBot.Core/NadekoBot.Core.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.9.10" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00937" />
+    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00998" />
     <PackageReference Include="CoreCLR-NCalc" Version="2.2.34" />
     <PackageReference Include="Google.Apis.Urlshortener.v1" Version="1.35.1.138" />
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.35.1.1226" />


### PR DESCRIPTION
I have recently noticed I'm not able to run the bot on a fresh environment.

build log:
```
+ dotnet publish -c Release -o /app
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

/NadekoBot/src/NadekoBot/NadekoBot.csproj : warning NU1603: NadekoBot.Core depends on Discord.Net (>= 2.0.0-beta2-00937) but Discord.Net 2.0.0-beta2-00937 was not found. An approximate best match of Discord.Net 2.0.0-beta2-00944 was resolved.
/NadekoBot/NadekoBot.Core/NadekoBot.Core.csproj : warning NU1603: NadekoBot.Core depends on Discord.Net (>= 2.0.0-beta2-00937) but Discord.Net 2.0.0-beta2-00937 was not found. An approximate best match of Discord.Net 2.0.0-beta2-00944 was resolved. [/NadekoBot/src/NadekoBot/NadekoBot.csproj]
  Restore completed in 53.18 ms for /NadekoBot/src/NadekoBot/NadekoBot.csproj.
  Restore completed in 53.34 ms for /NadekoBot/NadekoBot.Core/NadekoBot.Core.csproj.
/NadekoBot/src/NadekoBot/NadekoBot.csproj : warning NU1603: NadekoBot.Core depends on Discord.Net (>= 2.0.0-beta2-00937) but Discord.Net 2.0.0-beta2-00937 was not found. An approximate best match of Discord.Net 2.0.0-beta2-00944 was resolved.
/NadekoBot/NadekoBot.Core/NadekoBot.Core.csproj : warning NU1603: NadekoBot.Core depends on Discord.Net (>= 2.0.0-beta2-00937) but Discord.Net 2.0.0-beta2-00937 was not found. An approximate best match of Discord.Net 2.0.0-beta2-00944 was resolved.
  NadekoBot.Core -> /NadekoBot/NadekoBot.Core/bin/Release/netcoreapp2.1/NadekoBot.Core.dll
  NadekoBot -> /NadekoBot/src/NadekoBot/bin/Release/netcoreapp2.1/NadekoBot.dll
  NadekoBot -> /app/
```

nadeko output:
```
nadeko_1  | 2018-10-01T13:37:17.869851397Z -1 15:37:17 ShardsCoordinator | Shard 0 is scheduled for a restart because it's unresponsive.
nadeko_1  | 2018-10-01T13:37:20.784679070Z -1 15:37:20 ShardsCoordinator | Auto-restarting shard 0, 1 more in queue.
nadeko_1  | 2018-10-01T13:37:24.227425585Z
nadeko_1  | 2018-10-01T13:37:24.243242820Z Unhandled Exception: System.MissingMethodException: Method not found: 'System.Threading.Tasks.Task`1<Discord.IUserMessage> Discord.IMessageChannel.SendFileAsync(System.String, System.String, Boolean, Discord.Embed, Discord.RequestOptions)'.
nadeko_1  | 2018-10-01T13:37:24.243261760Z    at Discord.WebSocket.ClientState..ctor(Int32 guildCount, Int32 dmChannelCount)
nadeko_1  | 2018-10-01T13:37:24.243264694Z    at Discord.WebSocket.DiscordSocketClient..ctor(DiscordSocketConfig config, DiscordSocketApiClient client, SemaphoreSlim groupLock, DiscordSocketClient parentClient)
nadeko_1  | 2018-10-01T13:37:24.243267067Z    at NadekoBot.NadekoBot..ctor(Int32 shardId, Int32 parentProcessId) in /NadekoBot/NadekoBot.Core/Services/NadekoBot.cs:line 80
nadeko_1  | 2018-10-01T13:37:24.243269320Z    at NadekoBot.Program.Main(String[] args) in /NadekoBot/src/NadekoBot/Program.cs:line 15
nadeko_1  | 2018-10-01T13:37:24.243272327Z    at NadekoBot.Program.<Main>(String[] args)
```

It seems the Discord beta repository does not contains the package Discord.Net 2.0.0-beta2-00937 anymore.
This update ensures all Discord.* package are at the same version.
I've choosen v998 as it's the last available version.