### PR TITLE
docker: configure the Shard startup command and redis options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     volumes:
       - ./credentials.json:/app/credentials.json:ro
       - ./data:/app/data
+    environment:
+      NadekoBot_RedisOptions: redis,name=nadeko
+      NadekoBot_ShardRunCommand: dotnet
+      NadekoBot_ShardRunArguments: NadekoBot.dll {0} {1}
     labels:
       "com.centurylinklabs.watchtower.enable": "true"
   redis:


### PR DESCRIPTION
fix #2603 in a non-intrusive way to keep credentials.json portable